### PR TITLE
Fix broken method (get_all_unfinished_remaining_tasks_for_pair)

### DIFF
--- a/lib/database_interaction/task_remaining_chunk/task_remaining_chunk_context.ex
+++ b/lib/database_interaction/task_remaining_chunk/task_remaining_chunk_context.ex
@@ -96,7 +96,7 @@ defmodule DatabaseInteraction.TaskRemainingChunkContext do
       on: cp.id == ts.currency_pair_id,
       on: ts.id == trc.task_status_id,
       where: cp.id == ^pair.id,
-      where: cp.done_or_not == false
+      where: trc.done_or_not == false
     )
     |> DatabaseInteraction.Repo.get_repo().all()
   end


### PR DESCRIPTION
You have broken the function in this commit: https://github.com/distributed-applications-2021/assignment-database-interaction/commit/3ed697ed1b9f719dce024e8b3ce5a37de4a8fc0f

By calling the function you will get an error that the 'CurrencyPair' table has no field 'done_or_not ', Which is true :joy:.

